### PR TITLE
Feat transition animation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "[svelte]": {
+    "editor.defaultFormatter": "svelte.svelte-vscode"
+  }
+}

--- a/resources/fixtures/data/mixed-variant-mixed-aspect-ratios.json
+++ b/resources/fixtures/data/mixed-variant-mixed-aspect-ratios.json
@@ -1,6 +1,6 @@
 {
   "title": "FIXTURE: Mixed variant with mixed aspect ratios",
-  "subtitle": "Contains two graphics with same aspect ratios, two variants, highlighted text & transition animations",
+  "subtitle": "Contains two graphics with same aspect ratios, two variants, highlighted text",
   "acronym": "gra.",
   "steps": [
     {
@@ -213,6 +213,6 @@
   ],
   "notes": "Anmerkung",
   "options": {
-    "enableAnimation": true
+    "disableAnimation": false
   }
 }

--- a/resources/fixtures/data/mixed-variant-mixed-aspect-ratios.json
+++ b/resources/fixtures/data/mixed-variant-mixed-aspect-ratios.json
@@ -1,0 +1,216 @@
+{
+  "title": "FIXTURE: Mixed variant with mixed aspect ratios",
+  "subtitle": "Contains two graphics with same aspect ratios, two variants & highlighted text",
+  "acronym": "gra.",
+  "steps": [
+    {
+      "text": "Ein Tor und ein Wachhund. Nur die Villa ist unsichtbar. Ist da ein Briefkasten auszumachen im Schmiedeeisengitter? Wer hat Post für den Dracula in den kalten Wäldern am Horizont? Vielleicht der Waadtländer Schriftsteller Jacques Chessex? Dessen Roman «Der Vampir von Ropraz» spielt in einer ähnlichen Gegend des Schweizer Juras wie die, in der auch das Dorf La Brévine liegt. In dessen Umgebung hat Monique Jacot 1976 diese Aufnahme gemacht.",
+      "variants": [
+        {
+          "asset": {
+            "key": "2021/08/23/01-018302caf2c4334cf04594662d1edcae.jpeg",
+            "url": "https://nzz-q-assets-stage.s3.eu-west-1.amazonaws.com/2021/08/23/01-018302caf2c4334cf04594662d1edcae.jpeg",
+            "size": 224921,
+            "type": "image/jpeg",
+            "width": 2000,
+            "height": 1331
+          }
+        }
+      ]
+    },
+    {
+      "text": "So kennen Sie die Schweiz mit ihren 26 Kantonen. Würde man die Grenzen jedoch anhand von Facebook-Freundschaften neu ziehen, ergäbe sich, je nach Kanton, ein ganz anderes Bild.",
+      "variants": [
+        {
+          "asset": {
+            "key": "2021/07/08/Schweiz-mw-80b589f567cbcdd221f0ff9585e53fd4.png",
+            "url": "https://nzz-q-assets-stage.s3.eu-west-1.amazonaws.com/2021/07/08/Schweiz-mw-80b589f567cbcdd221f0ff9585e53fd4.png",
+            "size": 39993,
+            "type": "image/png",
+            "width": 1400,
+            "height": 1552
+          }
+        },
+        {
+          "minWidth": 500,
+          "asset": {
+            "key": "2021/07/08/Schweiz-cw-43f630f4a5585ec437f8acf5e51e5b5c.png",
+            "url": "https://nzz-q-assets-stage.s3.eu-west-1.amazonaws.com/2021/07/08/Schweiz-cw-43f630f4a5585ec437f8acf5e51e5b5c.png",
+            "size": 60062,
+            "type": "image/png",
+            "width": 2520,
+            "height": 2060
+          }
+        }
+      ],
+      "highlightedTexts": [
+        {
+          "type": "background",
+          "preventLineBreak": false,
+          "text": "Schweiz",
+          "color": 0
+        },
+        {
+          "type": "underline",
+          "color": 1,
+          "preventLineBreak": true,
+          "text": "26 Kantonen"
+        },
+        {
+          "type": "bold",
+          "color": 0,
+          "preventLineBreak": false,
+          "text": "Facebook-Freundschaften"
+        }
+      ]
+    },
+    {
+      "text": "Die Zürcher haben Freunde in allen Kantonen der Schweiz und auch im Ausland. Zürich ist der Kanton der am besten über Facebook vernetzt ist. Zum Beispiel auch in entfernte Regionen in Portugal oder Italien.",
+      "variants": [
+        {
+          "asset": {
+            "key": "2021/07/08/Zurich-mw-481a54cbcef8db00a05137a9208aa2f3.png",
+            "url": "https://nzz-q-assets-stage.s3.eu-west-1.amazonaws.com/2021/07/08/Zurich-mw-481a54cbcef8db00a05137a9208aa2f3.png",
+            "size": 65935,
+            "type": "image/png",
+            "width": 1400,
+            "height": 1552
+          }
+        },
+        {
+          "minWidth": 500,
+          "asset": {
+            "key": "2021/07/08/Zurich-cw-0a140108d70094bd0ca059b6ca16b529.png",
+            "url": "https://nzz-q-assets-stage.s3.eu-west-1.amazonaws.com/2021/07/08/Zurich-cw-0a140108d70094bd0ca059b6ca16b529.png",
+            "size": 96462,
+            "type": "image/png",
+            "width": 2520,
+            "height": 2060
+          }
+        }
+      ],
+      "highlightedTexts": [
+        {
+          "type": "background",
+          "preventLineBreak": false,
+          "text": "Zürcher",
+          "color": 1
+        }
+      ]
+    },
+    {
+      "text": "Kein Hobby-Fotograf kann sich ein solches Sujet entgehen lassen. Und fast jeder Fotograf, der an einem solchen Bienenhaus vorübergeht und bei Sinnen ist, wird genau dies denken – und gerade darum kein Bild machen. Leonardo Bezzola sah 1971 das «Bienenhaus bei Flaach», ging womöglich daran vorüber, weil er dachte, wie jeder besonnene Fotograf denken würde, ging dann aber vielleicht wieder zurück, schaute noch einmal genauer hin, verstand den Witz erst jetzt und machte dieses Bild von den surrealen Bärten, die ums Haus herum einen übergrossen Zugang zum Bienenstock nachbilden.",
+      "variants": [
+        {
+          "asset": {
+            "key": "2021/08/23/02-bfde73dff0d1f69124debd3981d2e0e4.jpeg",
+            "url": "https://nzz-q-assets-stage.s3.eu-west-1.amazonaws.com/2021/08/23/02-bfde73dff0d1f69124debd3981d2e0e4.jpeg",
+            "size": 685426,
+            "type": "image/jpeg",
+            "width": 2000,
+            "height": 1517
+          }
+        }
+      ]
+    },
+    {
+      "text": "Barnabás Bosshart hat Gesichter fotografiert, zarte von Kindern, zerfurchte von alten Menschen, Gesichter der Welt, solche in Afghanistan, in Pakistan, in China oder Brasilien. Er porträtierte Persönlichkeiten wie die französische Schriftstellerin Anaïs Nin, die Filmstars James Stewart und Helmut Berger oder bekannte Schweizer wie Max Frisch, Jean Ziegler, Mario Botta. Er hatte aber auch die geschminkten Gesichter der Hochglanzmagazine vor der Linse. Und wusste hinter die perfekte Fassade der Modebranche zu blicken wie auf dieser Werbeaufnahme von 1971.",
+      "variants": [
+        {
+          "asset": {
+            "key": "2021/08/23/03-2f468943a2fdb09564adcfb9afe04659.jpeg",
+            "url": "https://nzz-q-assets-stage.s3.eu-west-1.amazonaws.com/2021/08/23/03-2f468943a2fdb09564adcfb9afe04659.jpeg",
+            "size": 208406,
+            "type": "image/jpeg",
+            "width": 2000,
+            "height": 2015
+          }
+        }
+      ]
+    },
+    {
+      "text": "Was macht der Mann bloss mit seinem Gesicht? Das ist doch keine Knautschzone. Aber was für eine präzise Komposition ist Henriette Grindat 1972 mit diesem Bild gelungen! Wie der Daumen von links unten einen Bogen gegen die Bildmitte schlägt, wie der Handknöchel einen harten rechten Winkel bildet und wie die Nase gleichermassen entschieden von oben ins Bild dringt! «Yersin» hat Grindat dieses auf Linien, Falten und Flächen reduzierte Porträt genannt, nach ihrem Ehemann, dem Künstler Albert-Edgar Yersin.",
+      "variants": [
+        {
+          "asset": {
+            "key": "2021/08/23/04-331f63975e973bfb1145503483c3b124.jpeg",
+            "url": "https://nzz-q-assets-stage.s3.eu-west-1.amazonaws.com/2021/08/23/04-331f63975e973bfb1145503483c3b124.jpeg",
+            "size": 407894,
+            "type": "image/jpeg",
+            "width": 2000,
+            "height": 1466
+          }
+        }
+      ]
+    },
+    {
+      "text": "Ein eingeschlagener Pflock oder ein Strunk in der Öde (ohne Titel, um 1970–1980) macht einen Ort zur Gegenwart und setzt uns Betrachter in Bezug zum Horizont. Der schweizerisch-amerikanische Fotograf Robert Frank, der durch seine Land-und-Leute-Dokumentation «The Americans» (1958) berühmt wurde, war auch ein Landvermesser: Mit dem lichtempfindlichen Organ der Kamera tastete er Heimat auf ihre Essenz ab.",
+      "variants": [
+        {
+          "asset": {
+            "key": "2021/08/23/05-5f437d250f008782a5f431cd851fd3a2.jpeg",
+            "url": "https://nzz-q-assets-stage.s3.eu-west-1.amazonaws.com/2021/08/23/05-5f437d250f008782a5f431cd851fd3a2.jpeg",
+            "size": 207386,
+            "type": "image/jpeg",
+            "width": 1332,
+            "height": 2000
+          }
+        }
+      ]
+    },
+    {
+      "text": "Nicht nur Zäune, auch Grenzen sind in der Schweiz der siebziger Jahre durchlässiger geworden. Und selbst zwischen den Geschlechtern wurde mit der Einführung des Frauenstimmrechts nicht mehr so harsch getrennt. Die Schweiz öffnete sich gegenüber Europa, es war die Zeit des Beitritts zu verschiedenen internationalen Organisationen wie etwa 1973 zur OSZE. Auf Werner Gadligers Fotografie «Scheuren, Forch» (um 1972) werden sich die Nebel wohl schon bald etwas lichten.",
+      "variants": [
+        {
+          "asset": {
+            "key": "2021/08/23/06-7041bf379324e5cbb1fe64a664b2babf.jpeg",
+            "url": "https://nzz-q-assets-stage.s3.eu-west-1.amazonaws.com/2021/08/23/06-7041bf379324e5cbb1fe64a664b2babf.jpeg",
+            "size": 143435,
+            "type": "image/jpeg",
+            "width": 2000,
+            "height": 1460
+          }
+        }
+      ]
+    },
+    {
+      "text": "Von der Skispitze bis zum Zipfel der Zipfelmütze ist alles weiss in René Groeblis Stilstudie des «Ski-Langläufer-Champions Alois Kälin» (1970/71). Wie ein Engel schwebt er durch den blauen Himmel. So blütenweiss und unbeschwert, so stolz und unschuldig war der Sport in den Zeiten, als Alois (Wisel) Kälin seine stillen Runden im Schnee drehte.",
+      "variants": [
+        {
+          "asset": {
+            "key": "2021/08/23/07-1a1e8081f1e9f78b89ed7a846fe86001.jpeg",
+            "url": "https://nzz-q-assets-stage.s3.eu-west-1.amazonaws.com/2021/08/23/07-1a1e8081f1e9f78b89ed7a846fe86001.jpeg",
+            "size": 204142,
+            "type": "image/jpeg",
+            "width": 2000,
+            "height": 1333
+          }
+        }
+      ]
+    }
+  ],
+  "highlightedTextColors": [
+    {
+      "color": "#3852EE"
+    },
+    {
+      "color": "#0C1E8D"
+    }
+  ],
+  "transitionAnimation": true,
+  "sources": [
+    {
+      "link": {},
+      "text": "ESA"
+    },
+    {
+      "link": {},
+      "text": "Copernicus"
+    },
+    {
+      "link": {},
+      "text": "OSM"
+    }
+  ],
+  "notes": "Anmerkung"
+}

--- a/resources/fixtures/data/mixed-variant-mixed-aspect-ratios.json
+++ b/resources/fixtures/data/mixed-variant-mixed-aspect-ratios.json
@@ -197,7 +197,6 @@
       "color": "#0C1E8D"
     }
   ],
-  "transitionAnimation": true,
   "sources": [
     {
       "link": {},
@@ -212,5 +211,8 @@
       "text": "OSM"
     }
   ],
-  "notes": "Anmerkung"
+  "notes": "Anmerkung",
+  "options": {
+    "enableAnimation": true
+  }
 }

--- a/resources/fixtures/data/mixed-variant-mixed-aspect-ratios.json
+++ b/resources/fixtures/data/mixed-variant-mixed-aspect-ratios.json
@@ -1,6 +1,6 @@
 {
   "title": "FIXTURE: Mixed variant with mixed aspect ratios",
-  "subtitle": "Contains two graphics with same aspect ratios, two variants & highlighted text",
+  "subtitle": "Contains two graphics with same aspect ratios, two variants, highlighted text & transition animations",
   "acronym": "gra.",
   "steps": [
     {

--- a/resources/fixtures/data/single-variant-different-aspect-ratios.json
+++ b/resources/fixtures/data/single-variant-different-aspect-ratios.json
@@ -1,6 +1,6 @@
 {
   "title": "FIXTURE: Single variant, different aspect ratios",
-  "subtitle": "Subtitle",
+  "subtitle": "disabled animations",
   "acronym": "gra.",
   "steps": [
     {
@@ -125,6 +125,6 @@
   ],
   "notes": "Anmerkung",
   "options": {
-    "enableAnimation": false
+    "disableAnimation": true
   }
 }

--- a/resources/fixtures/data/single-variant-different-aspect-ratios.json
+++ b/resources/fixtures/data/single-variant-different-aspect-ratios.json
@@ -109,7 +109,6 @@
       ]
     }
   ],
-  "transitionAnimation": false,
   "sources": [
     {
       "link": {},
@@ -124,5 +123,8 @@
       "text": "OSM"
     }
   ],
-  "notes": "Anmerkung"
+  "notes": "Anmerkung",
+  "options": {
+    "enableAnimation": false
+  }
 }

--- a/resources/fixtures/data/single-variant-different-aspect-ratios.json
+++ b/resources/fixtures/data/single-variant-different-aspect-ratios.json
@@ -109,7 +109,7 @@
       ]
     }
   ],
-  "transitionAnimation": true,
+  "transitionAnimation": false,
   "sources": [
     {
       "link": {},

--- a/resources/fixtures/data/single-variant-different-aspect-ratios.json
+++ b/resources/fixtures/data/single-variant-different-aspect-ratios.json
@@ -1,0 +1,128 @@
+{
+  "title": "FIXTURE: Single variant, different aspect ratios",
+  "subtitle": "Subtitle",
+  "acronym": "gra.",
+  "steps": [
+    {
+      "text": "Ein Tor und ein Wachhund. Nur die Villa ist unsichtbar. Ist da ein Briefkasten auszumachen im Schmiedeeisengitter? Wer hat Post für den Dracula in den kalten Wäldern am Horizont? Vielleicht der Waadtländer Schriftsteller Jacques Chessex? Dessen Roman «Der Vampir von Ropraz» spielt in einer ähnlichen Gegend des Schweizer Juras wie die, in der auch das Dorf La Brévine liegt. In dessen Umgebung hat Monique Jacot 1976 diese Aufnahme gemacht.",
+      "variants": [
+        {
+          "asset": {
+            "key": "2021/08/23/01-018302caf2c4334cf04594662d1edcae.jpeg",
+            "url": "https://nzz-q-assets-stage.s3.eu-west-1.amazonaws.com/2021/08/23/01-018302caf2c4334cf04594662d1edcae.jpeg",
+            "size": 224921,
+            "type": "image/jpeg",
+            "width": 2000,
+            "height": 1331
+          }
+        }
+      ]
+    },
+    {
+      "text": "Kein Hobby-Fotograf kann sich ein solches Sujet entgehen lassen. Und fast jeder Fotograf, der an einem solchen Bienenhaus vorübergeht und bei Sinnen ist, wird genau dies denken – und gerade darum kein Bild machen. Leonardo Bezzola sah 1971 das «Bienenhaus bei Flaach», ging womöglich daran vorüber, weil er dachte, wie jeder besonnene Fotograf denken würde, ging dann aber vielleicht wieder zurück, schaute noch einmal genauer hin, verstand den Witz erst jetzt und machte dieses Bild von den surrealen Bärten, die ums Haus herum einen übergrossen Zugang zum Bienenstock nachbilden.",
+      "variants": [
+        {
+          "asset": {
+            "key": "2021/08/23/02-bfde73dff0d1f69124debd3981d2e0e4.jpeg",
+            "url": "https://nzz-q-assets-stage.s3.eu-west-1.amazonaws.com/2021/08/23/02-bfde73dff0d1f69124debd3981d2e0e4.jpeg",
+            "size": 685426,
+            "type": "image/jpeg",
+            "width": 2000,
+            "height": 1517
+          }
+        }
+      ]
+    },
+    {
+      "text": "Barnabás Bosshart hat Gesichter fotografiert, zarte von Kindern, zerfurchte von alten Menschen, Gesichter der Welt, solche in Afghanistan, in Pakistan, in China oder Brasilien. Er porträtierte Persönlichkeiten wie die französische Schriftstellerin Anaïs Nin, die Filmstars James Stewart und Helmut Berger oder bekannte Schweizer wie Max Frisch, Jean Ziegler, Mario Botta. Er hatte aber auch die geschminkten Gesichter der Hochglanzmagazine vor der Linse. Und wusste hinter die perfekte Fassade der Modebranche zu blicken wie auf dieser Werbeaufnahme von 1971.",
+      "variants": [
+        {
+          "asset": {
+            "key": "2021/08/23/03-2f468943a2fdb09564adcfb9afe04659.jpeg",
+            "url": "https://nzz-q-assets-stage.s3.eu-west-1.amazonaws.com/2021/08/23/03-2f468943a2fdb09564adcfb9afe04659.jpeg",
+            "size": 208406,
+            "type": "image/jpeg",
+            "width": 2000,
+            "height": 2015
+          }
+        }
+      ]
+    },
+    {
+      "text": "Was macht der Mann bloss mit seinem Gesicht? Das ist doch keine Knautschzone. Aber was für eine präzise Komposition ist Henriette Grindat 1972 mit diesem Bild gelungen! Wie der Daumen von links unten einen Bogen gegen die Bildmitte schlägt, wie der Handknöchel einen harten rechten Winkel bildet und wie die Nase gleichermassen entschieden von oben ins Bild dringt! «Yersin» hat Grindat dieses auf Linien, Falten und Flächen reduzierte Porträt genannt, nach ihrem Ehemann, dem Künstler Albert-Edgar Yersin.",
+      "variants": [
+        {
+          "asset": {
+            "key": "2021/08/23/04-331f63975e973bfb1145503483c3b124.jpeg",
+            "url": "https://nzz-q-assets-stage.s3.eu-west-1.amazonaws.com/2021/08/23/04-331f63975e973bfb1145503483c3b124.jpeg",
+            "size": 407894,
+            "type": "image/jpeg",
+            "width": 2000,
+            "height": 1466
+          }
+        }
+      ]
+    },
+    {
+      "text": "Ein eingeschlagener Pflock oder ein Strunk in der Öde (ohne Titel, um 1970–1980) macht einen Ort zur Gegenwart und setzt uns Betrachter in Bezug zum Horizont. Der schweizerisch-amerikanische Fotograf Robert Frank, der durch seine Land-und-Leute-Dokumentation «The Americans» (1958) berühmt wurde, war auch ein Landvermesser: Mit dem lichtempfindlichen Organ der Kamera tastete er Heimat auf ihre Essenz ab.",
+      "variants": [
+        {
+          "asset": {
+            "key": "2021/08/23/05-5f437d250f008782a5f431cd851fd3a2.jpeg",
+            "url": "https://nzz-q-assets-stage.s3.eu-west-1.amazonaws.com/2021/08/23/05-5f437d250f008782a5f431cd851fd3a2.jpeg",
+            "size": 207386,
+            "type": "image/jpeg",
+            "width": 1332,
+            "height": 2000
+          }
+        }
+      ]
+    },
+    {
+      "text": "Nicht nur Zäune, auch Grenzen sind in der Schweiz der siebziger Jahre durchlässiger geworden. Und selbst zwischen den Geschlechtern wurde mit der Einführung des Frauenstimmrechts nicht mehr so harsch getrennt. Die Schweiz öffnete sich gegenüber Europa, es war die Zeit des Beitritts zu verschiedenen internationalen Organisationen wie etwa 1973 zur OSZE. Auf Werner Gadligers Fotografie «Scheuren, Forch» (um 1972) werden sich die Nebel wohl schon bald etwas lichten.",
+      "variants": [
+        {
+          "asset": {
+            "key": "2021/08/23/06-7041bf379324e5cbb1fe64a664b2babf.jpeg",
+            "url": "https://nzz-q-assets-stage.s3.eu-west-1.amazonaws.com/2021/08/23/06-7041bf379324e5cbb1fe64a664b2babf.jpeg",
+            "size": 143435,
+            "type": "image/jpeg",
+            "width": 2000,
+            "height": 1460
+          }
+        }
+      ]
+    },
+    {
+      "text": "Von der Skispitze bis zum Zipfel der Zipfelmütze ist alles weiss in René Groeblis Stilstudie des «Ski-Langläufer-Champions Alois Kälin» (1970/71). Wie ein Engel schwebt er durch den blauen Himmel. So blütenweiss und unbeschwert, so stolz und unschuldig war der Sport in den Zeiten, als Alois (Wisel) Kälin seine stillen Runden im Schnee drehte.",
+      "variants": [
+        {
+          "asset": {
+            "key": "2021/08/23/07-1a1e8081f1e9f78b89ed7a846fe86001.jpeg",
+            "url": "https://nzz-q-assets-stage.s3.eu-west-1.amazonaws.com/2021/08/23/07-1a1e8081f1e9f78b89ed7a846fe86001.jpeg",
+            "size": 204142,
+            "type": "image/jpeg",
+            "width": 2000,
+            "height": 1333
+          }
+        }
+      ]
+    }
+  ],
+  "transitionAnimation": true,
+  "sources": [
+    {
+      "link": {},
+      "text": "ESA"
+    },
+    {
+      "link": {},
+      "text": "Copernicus"
+    },
+    {
+      "link": {},
+      "text": "OSM"
+    }
+  ],
+  "notes": "Anmerkung"
+}

--- a/resources/fixtures/data/two-variants-highlighted-text.json
+++ b/resources/fixtures/data/two-variants-highlighted-text.json
@@ -1,6 +1,6 @@
 {
   "title": "FIXTURE: Two variants per step and highlighted text",
-  "subtitle": "Subtitle",
+  "subtitle": "with animated transitions",
   "acronym": "mrt.",
   "steps": [
     {

--- a/resources/fixtures/data/two-variants-highlighted-text.json
+++ b/resources/fixtures/data/two-variants-highlighted-text.json
@@ -262,6 +262,7 @@
       "color": "#0C1E8D"
     }
   ],
+  "transitionAnimation": true,
   "sources": [
     {
       "link": {},

--- a/resources/fixtures/data/two-variants-highlighted-text.json
+++ b/resources/fixtures/data/two-variants-highlighted-text.json
@@ -1,6 +1,6 @@
 {
   "title": "FIXTURE: Two variants per step and highlighted text",
-  "subtitle": "with animated transitions",
+  "subtitle": "Subtitle",
   "acronym": "mrt.",
   "steps": [
     {
@@ -278,6 +278,6 @@
   ],
   "notes": "Anmerkung",
   "options": {
-    "enableAnimation": true
+    "disableAnimation": false
   }
 }

--- a/resources/fixtures/data/two-variants-highlighted-text.json
+++ b/resources/fixtures/data/two-variants-highlighted-text.json
@@ -262,7 +262,6 @@
       "color": "#0C1E8D"
     }
   ],
-  "transitionAnimation": true,
   "sources": [
     {
       "link": {},
@@ -277,5 +276,8 @@
       "text": "OSM"
     }
   ],
-  "notes": "Anmerkung"
+  "notes": "Anmerkung",
+  "options": {
+    "enableAnimation": true
+  }
 }

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -42,11 +42,6 @@
         }
       ]
     },
-    "transitionAnimation": {
-      "title": "Überblendungsanimation",
-      "type": "boolean",
-      "default": false
-    },
     "steps": {
       "title": "Schritte",
       "type": "array",
@@ -202,6 +197,17 @@
     "notes": {
       "title": "Anmerkungen",
       "type": "string"
+    }
+  },
+  "options": {
+    "title": "Optionen",
+    "type": "object",
+    "properties": {
+      "enableAnimation": {
+        "title": "Überblendung aktivieren",
+        "type": "boolean",
+        "default": false
+      }
     }
   },
   "required": ["title"]

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -203,8 +203,8 @@
     "title": "Optionen",
     "type": "object",
     "properties": {
-      "enableAnimation": {
-        "title": "Überblendung aktivieren",
+      "disableAnimation": {
+        "title": "Überblendung deaktivieren",
         "type": "boolean",
         "default": false
       }

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -42,6 +42,11 @@
         }
       ]
     },
+    "transitionAnimation": {
+      "title": "Überblendungsanimation",
+      "type": "boolean",
+      "default": false
+    },
     "steps": {
       "title": "Schritte",
       "type": "array",

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -197,16 +197,16 @@
     "notes": {
       "title": "Anmerkungen",
       "type": "string"
-    }
-  },
-  "options": {
-    "title": "Optionen",
-    "type": "object",
-    "properties": {
-      "disableAnimation": {
-        "title": "Überblendung deaktivieren",
-        "type": "boolean",
-        "default": false
+    },
+    "options": {
+      "title": "Optionen",
+      "type": "object",
+      "properties": {
+        "disableAnimation": {
+          "title": "Überblendung deaktivieren",
+          "type": "boolean",
+          "default": false
+        }
       }
     }
   },

--- a/routes/fixtures/data.js
+++ b/routes/fixtures/data.js
@@ -5,6 +5,7 @@ const fixtureDataDirectory = "../../resources/fixtures/data";
 const fixtureData = [
   require(`${fixtureDataDirectory}/two-variants-highlighted-text.json`),
   require(`${fixtureDataDirectory}/single-variant-different-aspect-ratios.json`),
+  require(`${fixtureDataDirectory}/mixed-variant-mixed-aspect-ratios.json`),
 ];
 
 module.exports = {

--- a/routes/fixtures/data.js
+++ b/routes/fixtures/data.js
@@ -4,6 +4,7 @@ const fixtureDataDirectory = "../../resources/fixtures/data";
 // has to be in sync with files created in build task - see ../../tasks/build.js
 const fixtureData = [
   require(`${fixtureDataDirectory}/two-variants-highlighted-text.json`),
+  require(`${fixtureDataDirectory}/single-variant-different-aspect-ratios.json`),
 ];
 
 module.exports = {

--- a/views/ScrollGraphic.svelte
+++ b/views/ScrollGraphic.svelte
@@ -5,6 +5,10 @@
   export let item;
   export let imageServiceUrl;
 
+  if (!item.options) {
+    item.options = {};
+  }
+
   let containerWidth;
 </script>
 

--- a/views/components/ScrollContainer.svelte
+++ b/views/components/ScrollContainer.svelte
@@ -85,11 +85,13 @@
   $: imageUrlsReverse = imageUrls.map((image, id) => ({ id, image })).reverse();
 
   // Asserts if adjacent image(s) have different aspect ratio
-  function aspectRatioChanges(i, index, imgArrayLength) {
-    const iReversed = Math.abs(i - (imgArrayLength - 1));
-    const isPreviousImg = index - 1 === iReversed;
-    const isCurrentImg = index === iReversed;
-    const isNextImg = index + 1 === iReversed;
+  function aspectRatioChanges(svelteLoopIndex, index, imgArrayLength) {
+    const svelteLoopIndexReversed = Math.abs(
+      svelteLoopIndex - (imgArrayLength - 1)
+    );
+    const isPreviousImg = index - 1 === svelteLoopIndexReversed;
+    const isCurrentImg = index === svelteLoopIndexReversed;
+    const isNextImg = index + 1 === svelteLoopIndexReversed;
 
     if (isPreviousImg) {
       return aspectRatio !== previousAspectRatio;

--- a/views/components/ScrollContainer.svelte
+++ b/views/components/ScrollContainer.svelte
@@ -134,9 +134,9 @@
           <img
             class="q-scroll-graphic-image"
             class:q-scroll-graphic-image--transition-animation={item.options
-              .enableAnimation === undefined || item.options.enableAnimation}
-            class:q-scroll-graphic-image--fade-in-transition-animation={item
-              .options.enableAnimation &&
+              .disableAnimation === undefined || !item.options.disableAnimation}
+            class:q-scroll-graphic-image--fade-in-transition-animation={!item
+              .options.disableAnimation &&
               aspectRatioChanges(i, index, imageUrlsReverse.length)}
             class:q-scroll-graphic-image--horizontal-fit={imageHeight <=
               windowHeight - top}

--- a/views/components/ScrollContainer.svelte
+++ b/views/components/ScrollContainer.svelte
@@ -133,7 +133,8 @@
           -->
           <img
             class="q-scroll-graphic-image"
-            class:q-scroll-graphic-image--transition-animation={item.transitionAnimation}
+            class:q-scroll-graphic-image--transition-animation={item.transitionAnimation ===
+              undefined || item.transitionAnimation}
             class:q-scroll-graphic-image--fade-in-transition-animation={item.transitionAnimation &&
               aspectRatioChanges(i, index, imageUrlsReverse.length)}
             class:q-scroll-graphic-image--horizontal-fit={imageHeight <=

--- a/views/components/ScrollContainer.svelte
+++ b/views/components/ScrollContainer.svelte
@@ -99,7 +99,10 @@
       {#each imageUrlsReverse as { id, image }}
         {#if image && [index - 1, index, index + 1].includes(id)}
           <img
-            class="q-scroll-graphic-image"
+            class="q-scroll-graphic-image 
+            {item.transitionAnimation
+              ? 'q-scroll-graphic-image--transition-animation'
+              : ''}"
             class:q-scroll-graphic-image--horizontal-fit={imageHeight <=
               windowHeight - top}
             class:q-scroll-graphic-image--vertical-fit={imageHeight >
@@ -134,6 +137,8 @@
   .q-scroll-graphic-image {
     position: absolute;
     background: currentColor;
+    visibility: visible;
+    opacity: 1;
   }
 
   .q-scroll-graphic-image--horizontal-fit {
@@ -148,7 +153,12 @@
 
   .q-scroll-graphic-image--hidden {
     visibility: hidden;
+    opacity: 0;
     /* On Safari the image will flicker without z-index: 1 */
     z-index: 1;
+  }
+
+  .q-scroll-graphic-image--transition-animation {
+    transition: visibility 0.35s ease-out, opacity 0.35s ease-out;
   }
 </style>

--- a/views/components/ScrollContainer.svelte
+++ b/views/components/ScrollContainer.svelte
@@ -133,9 +133,10 @@
           -->
           <img
             class="q-scroll-graphic-image"
-            class:q-scroll-graphic-image--transition-animation={item.transitionAnimation ===
-              undefined || item.transitionAnimation}
-            class:q-scroll-graphic-image--fade-in-transition-animation={item.transitionAnimation &&
+            class:q-scroll-graphic-image--transition-animation={item.options
+              .enableAnimation === undefined || item.options.enableAnimation}
+            class:q-scroll-graphic-image--fade-in-transition-animation={item
+              .options.enableAnimation &&
               aspectRatioChanges(i, index, imageUrlsReverse.length)}
             class:q-scroll-graphic-image--horizontal-fit={imageHeight <=
               windowHeight - top}


### PR DESCRIPTION
- Add transition animation option
- Add new fixture data for aspect ratio differences
- Add animation for same aspect ratio graphics
- Add specific fade-out animation in case of different aspect ratios
- Add fallback for older scroll-graphics (if transitionAnimation is not defined, it will be animated)

[Example 1 (Different Aspect Ratios)](https://www-stage.nzz.ch/storytelling/50-jahre-fotostiftung-winterthur-ld.1334803)
[Example 2 (Same Aspect Ratios) ](https://www-stage.nzz.ch/visuals/israel-palaestina-scrolly-test-ld.1334677)
Or take a look at the new fixture data.