### PR TITLE
Center image on mobile devices

### DIFF
--- a/views/components/ScrollContainer.svelte
+++ b/views/components/ScrollContainer.svelte
@@ -43,7 +43,14 @@
   $: {
     aspectRatio = images[index].width / images[index].height;
     imageHeight = containerWidth / aspectRatio;
-    top = windowHeight / 2 - imageHeight / 2;
+    // if the vertical center is smaller than 90px set distance to top to account for header
+    // else set distance to top to vertical center
+    const verticalCenter = windowHeight / 2 - imageHeight / 2;
+    if (verticalCenter < 90) {
+      top = 90;
+    } else {
+      top = verticalCenter;
+    }
     bottom = top + imageHeight;
 
     if (imageHeight > windowHeight - top) {

--- a/views/components/ScrollContainer.svelte
+++ b/views/components/ScrollContainer.svelte
@@ -43,20 +43,7 @@
   $: {
     aspectRatio = images[index].width / images[index].height;
     imageHeight = containerWidth / aspectRatio;
-    if (variant === "small") {
-      // set 90px distance to top on mobile
-      top = 90;
-    } else {
-      // if the vertical center is smaller than 90px set distance to top to account for header
-      // else set distance to top to vertical center
-      const verticalCenter = windowHeight / 2 - imageHeight / 2;
-      if (verticalCenter < 90) {
-        top = 90;
-      } else {
-        top = verticalCenter;
-      }
-    }
-
+    top = windowHeight / 2 - imageHeight / 2;
     bottom = top + imageHeight;
 
     if (imageHeight > windowHeight - top) {


### PR DESCRIPTION
This PR centers the image on mobile devices. This branch is deployed on production and can be tested for example in [this article](https://www.nzz.ch/zuerich/am-ende-der-richtplan-debatte-taucht-die-entscheidende-frage-auf-soll-die-stadt-zuerich-wirklich-in-diesem-ausmass-verdichtet-werden-ld.1653785). The image is now centered on mobile devices:

<img width="523" alt="Screenshot 2021-12-02 at 10 53 47" src="https://user-images.githubusercontent.com/1810384/144399120-6f850e8f-894b-40cb-841d-89b2c1dda7e5.png">

